### PR TITLE
orf experiment data

### DIFF
--- a/data/orf_experiment/README.md
+++ b/data/orf_experiment/README.md
@@ -1,0 +1,9 @@
+This directory contains experimental data for the ORF experiment.
+
+## Directory Structure
+- `orf_experiment/original_images/`: Original .tif images (490MB)
+- `orf_experiment/microsplit_images/`: Microsplit predictions (2.7GB)
+- `orf_experiment/cellprofiler_outputs/`: CellProfiler analysis results (233MB)
+
+## Data Location
+Data is stored locally and not tracked in Git for now due to size (3.4GB total).


### PR DESCRIPTION
example ORF experiment data for CPM workflow
- microsplit outputs (original images, predicted images, metadata files for cellprofiler)
- microsplit quantitative metrics
- illumination correction files
- cellprofiler output csv files
- README.md